### PR TITLE
fix(vue): update build for ssr compatibility

### DIFF
--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.3](https://github.com/laurenashpole/inner-image-zoom/compare/vue-inner-image-zoom@3.0.2...vue-inner-image-zoom@3.0.3) (2026-09-10)
+
+### Fixed
+
+- Build `es` and `lib` targets with `vue-loader` instead of shipping `.vue` files
+
 ## [3.0.2](https://github.com/laurenashpole/inner-image-zoom/compare/vue-inner-image-zoom@3.0.1...vue-inner-image-zoom@3.0.2) (2025-06-30)
 
 ### Fixed
@@ -45,7 +51,7 @@
 
 - `hideCloseButton` prop to hide the close button on touch devices.
 - `hideHint` prop to hide the magnifying glass icon.
-- `width`, `height`, and `hasSpacer` props to set the original image's width and height attributes and optionally generate a spacer based on those values to avoid cumulative layout shift. 
+- `width`, `height`, and `hasSpacer` props to set the original image's width and height attributes and optionally generate a spacer based on those values to avoid cumulative layout shift.
 - `zoomPreload` prop to load the zoomed image on render.
 - `zoomScale` prop to set the size of the zoomed image.
 - `zoomType` prop with "hover" option to trigger zoom on hover.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
   ],
   "author": "Lauren Ashpole",
   "description": "A Vue.js component for magnifying an image within its parent container 🔎",
-  "homepage": "https://github.com/laurenashpole/inner-image-zoom/packages/vue#readme",
+  "homepage": "https://github.com/laurenashpole/inner-image-zoom/tree/main/packages/vue#readme",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,11 +2,23 @@
   "name": "vue-inner-image-zoom",
   "version": "3.0.2",
   "main": "lib/index.js",
-  "module": "src/index.js",
+  "module": "es/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    },
+    "./styles.css": "./lib/styles.min.css"
+  },
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "lib",
+    "es",
     "umd",
-    "src"
+    "src/index.d.ts"
   ],
   "author": "Lauren Ashpole",
   "description": "A Vue.js component for magnifying an image within its parent container 🔎",

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -6,67 +6,145 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const { VueLoaderPlugin } = require('vue-loader');
 
+const getTargets = (framework) => {
+  if (framework === 'react') {
+    return ['lib', 'es'];
+  }
+
+  if (framework === 'vue') {
+    return ['lib', 'es', 'umd'];
+  }
+
+  return ['lib', 'umd'];
+};
+
+const getVueConfig = (target, config) => {
+  if (target === 'umd') {
+    return {
+      ...config,
+      output: {
+        ...config.output,
+        filename: 'index.js',
+        library: {
+          name: 'InnerImageZoom',
+          type: 'umd',
+          export: 'default'
+        }
+      }
+    };
+  }
+
+  if (target === 'lib') {
+    return {
+      ...config,
+      output: {
+        ...config.output,
+        filename: 'index.js',
+        library: {
+          type: 'commonjs2',
+          export: 'default'
+        }
+      },
+      externals: ['vue']
+    };
+  }
+
+  return {
+    ...config,
+    experiments: { outputModule: true },
+    output: {
+      ...config.output,
+      filename: 'index.js',
+      library: { type: 'module' },
+      chunkFormat: 'module',
+      environment: { module: true }
+    },
+    externals: ['vue'],
+    externalsType: 'module-import'
+  };
+};
+
+const getVanillaConfig = (target, config) => ({
+  ...config,
+  output: {
+    ...config.output,
+    filename: 'index.js',
+    library: 'InnerImageZoom',
+    libraryTarget: target === 'lib' ? 'var' : target,
+    ...(target === 'umd' && {
+      libraryExport: 'default'
+    })
+  }
+});
+
 module.exports = ({ framework = 'vanilla' }) => {
   const directory = path.resolve(__dirname, `packages/${framework}`);
 
-  return ['lib', ...(framework === 'react' ? ['es'] : ['umd'])].map((target) => ({
-    mode: 'production',
-    entry: [
-      ...(framework !== 'vue' ? [`${directory}/src/styles.css`] : []),
-      ...(framework !== 'react' ? [`${directory}/src`] : [])
-    ],
-    output: {
-      path: `${directory}/${target}`,
-      clean: true,
-      ...(framework !== 'react' && {
-        filename: 'index.js',
-        library: 'InnerImageZoom',
-        libraryTarget: target === 'lib' ? 'var' : target,
-        ...(target === 'umd' && {
-          libraryExport: 'default'
-        })
-      })
-    },
-    module: {
-      rules: [
-        { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] },
-        ...(framework === 'vue' ? [{ test: /\.vue$/, use: 'vue-loader' }] : []),
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          use: {
-            loader: 'babel-loader',
-            options: {
-              presets: ['@babel/preset-env']
+  return getTargets(framework).map((target) => {
+    const isVue = framework === 'vue';
+    const isReact = framework === 'react';
+
+    const config = {
+      mode: 'production',
+      entry: [
+        ...(isReact ? [] : [`${directory}/src/styles.css`]),
+        ...(!isReact ? [`${directory}/src`] : [`${directory}/src/styles.css`])
+      ],
+      output: {
+        path: `${directory}/${target}`,
+        clean: true
+      },
+      module: {
+        rules: [
+          { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] },
+          ...(isVue ? [{ test: /\.vue$/, use: 'vue-loader' }] : []),
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                presets: ['@babel/preset-env']
+              }
             }
           }
-        }
-      ]
-    },
-    plugins: [
-      new CopyPlugin({
-        patterns: [`${directory}/src/index.d.ts`]
-      }),
-      new MiniCssExtractPlugin({
-        filename: 'styles.min.css'
-      }),
-      ...(framework === 'vue'
-        ? [
-            new VueLoaderPlugin(),
-            new webpack.DefinePlugin({
-              __VUE_OPTIONS_API__: false
-            })
-          ]
-        : [])
-    ],
-    optimization: {
-      minimizer: [
-        `...`,
-        new RemoveEmptyScriptsPlugin(),
-        new CssMinimizerPlugin({
-          test: /\.min.css$/
-        })
-      ]
+        ]
+      },
+      plugins: [
+        new CopyPlugin({
+          patterns: [`${directory}/src/index.d.ts`]
+        }),
+        new MiniCssExtractPlugin({
+          filename: 'styles.min.css'
+        }),
+        ...(isVue
+          ? [
+              new VueLoaderPlugin(),
+              new webpack.DefinePlugin({
+                __VUE_OPTIONS_API__: false
+              })
+            ]
+          : [])
+      ],
+      optimization: {
+        minimizer: [
+          '...',
+          new RemoveEmptyScriptsPlugin(),
+          new CssMinimizerPlugin({
+            test: /\.min.css$/
+          })
+        ]
+      }
+    };
+
+    if (!isVue && !isReact) {
+      return getVanillaConfig(target, config);
     }
-  }));
+
+    if (isVue) {
+      return getVueConfig(target, config);
+    }
+
+    return config;
+  });
 };


### PR DESCRIPTION
This PR updates the Webpack config to build `lib` and `es` targets with `vue-loader` instead of shipping raw `.vue` files.