### PR TITLE
fix: vanilla return type

### DIFF
--- a/packages/vanilla/CHANGELOG.md
+++ b/packages/vanilla/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 (2026-09-10)
+
+## [1.1.0](https://github.com/laurenashpole/inner-image-zoom/compare/inner-image-zoom@1.0.0...inner-image-zoom@1.1.0) (2026-09-10)
+
+### Fixed
+
+- Update return type to `InnerImageZoom | InnerImageZoom[]` to support multiple elements matching selector.
+
 ## 1.0.0 (2025-03-06)
 
 ### Added

--- a/packages/vanilla/CHANGELOG.md
+++ b/packages/vanilla/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 (2026-09-10)
+# Changelog
 
 ## [1.1.0](https://github.com/laurenashpole/inner-image-zoom/compare/inner-image-zoom@1.0.0...inner-image-zoom@1.1.0) (2026-09-10)
 

--- a/packages/vanilla/src/index.d.ts
+++ b/packages/vanilla/src/index.d.ts
@@ -17,12 +17,7 @@ interface InnerImageZoomOptions {
   afterZoomOut?: () => void;
 }
 
-declare class InnerImageZoom {
-  constructor(
-    selector?: string,
-    options?: InnerImageZoomOptions
-  )
-
+interface InnerImageZoom {
   $closeButton: HTMLElement | null;
   $container: HTMLElement;
   $el: HTMLElement;
@@ -33,3 +28,13 @@ declare class InnerImageZoom {
   reinit(options?: InnerImageZoomOptions): void;
   uninit(): void;
 }
+
+interface InnerImageZoomConstructor {
+  new (
+    selector?: string,
+    options?: InnerImageZoomOptions
+  ): InnerImageZoom | InnerImageZoom[];
+  prototype: InnerImageZoom;
+}
+
+declare const InnerImageZoom: InnerImageZoomConstructor;

--- a/tests/vanilla.test-d.ts
+++ b/tests/vanilla.test-d.ts
@@ -1,9 +1,10 @@
 import InnerImageZoom from '../packages/vanilla/src';
+import { expectType } from 'tsd';
 
 const afterZoomIn = () => {};
 const afterZoomOut = () => {};
 
-new InnerImageZoom('.iiz', {
+const instance = new InnerImageZoom('.iiz', {
   zoomSrc: 'path/to/zoom-image.jpg',
   zoomScale: 1,
   zoomPreload: false,
@@ -17,3 +18,17 @@ new InnerImageZoom('.iiz', {
   afterZoomIn,
   afterZoomOut
 });
+
+expectType<InnerImageZoom | InnerImageZoom[]>(instance);
+
+if (Array.isArray(instance)) {
+  expectType<InnerImageZoom[]>(instance);
+
+  instance.forEach((iiz) => {
+    expectType<InnerImageZoom>(iiz);
+    iiz.uninit();
+  });
+} else {
+  expectType<InnerImageZoom>(instance);
+  instance.uninit();
+}


### PR DESCRIPTION
This PR updates the inner-image-zoom return type to `InnerImageZoom | InnerImageZoom[]` to support multiple elements matching the selector.